### PR TITLE
Comment-out Gigablast

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -510,20 +510,21 @@ engines:
     engine : genius
     shortcut : gen
 
-  - name : gigablast
-    engine : gigablast
-    shortcut : gb
-    timeout : 3.0
-    # Collection names to search in, separated by whitespaces.
-    # By default searx, queries the main collection.
-    #collections: main
-    # Search types, not required. possible values: images, news
-    #search_type: images
-    # Enable fast to get results quicker.
-    #fast : 1
-    disabled: True
-    additional_tests:
-      rosebud: *test_rosebud
+  # Gigablast is now offline
+  # - name : gigablast
+  #   engine : gigablast
+  #   shortcut : gb
+  #   timeout : 3.0
+      # Collection names to search in, separated by whitespaces.
+      # By default searx, queries the main collection.
+      #collections: main
+      # Search types, not required. possible values: images, news
+      #search_type: images
+      # Enable fast to get results quicker.
+      #fast : 1
+  #   disabled: True
+  #   additional_tests:
+  #     rosebud: *test_rosebud
 
   - name : gentoo
     engine : gentoo


### PR DESCRIPTION
Comment-out Gigablast from settings.yml (it's now offline [mojeek blog post](https://blog.mojeek.com/2023/05/farewell-gigablast.html), [wikipedia article](https://en.wikipedia.org/wiki/Gigablast))